### PR TITLE
Refactor Bundle out of Wasm package

### DIFF
--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -1,4 +1,4 @@
-package wasm
+package bundle
 
 import (
 	"os"
@@ -8,15 +8,15 @@ import (
 	"github.com/pkg/errors"
 )
 
-func TestReadBundle(t *testing.T) {
+func TestRead(t *testing.T) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		t.Error(errors.Wrap(err, "failed to get CWD"))
 	}
 
-	bundle, err := ReadBundle(filepath.Join(cwd, "./testdata/runnables.wasm.zip"))
+	bundle, err := Read(filepath.Join(cwd, "../wasm/testdata/runnables.wasm.zip"))
 	if err != nil {
-		t.Error(errors.Wrap(err, "failed to ReadBundle"))
+		t.Error(errors.Wrap(err, "failed to Read"))
 		return
 	}
 

--- a/bundle/bundlewritetester/main.go
+++ b/bundle/bundlewritetester/main.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/suborbital/hive-wasm/bundle"
 	"github.com/suborbital/hive-wasm/directive"
-	"github.com/suborbital/hive-wasm/wasm"
 )
 
 func main() {
@@ -66,7 +66,7 @@ func main() {
 		log.Fatal("failed to validate directive", err)
 	}
 
-	if err := wasm.WriteBundle(directive, files, "./runnables.wasm.zip"); err != nil {
+	if err := bundle.Write(directive, files, "./runnables.wasm.zip"); err != nil {
 		log.Fatal("failed to WriteBundle", err)
 	}
 

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,7 @@ github.com/suborbital/grav v0.0.11 h1:5S63w/Z/2ZsiekIDhg+CQxiVcxLp0vM0UaREOdul3I
 github.com/suborbital/grav v0.0.11/go.mod h1:fN837ibcYZILUd/nKoSaEbo+oTSGRtTbbm/MiwmM3Pw=
 github.com/suborbital/hive v0.1.3 h1:b29wRkR6Vg1LiPF3H3bfJq+N2xY2AQl0H+fkwC+MJtk=
 github.com/suborbital/hive v0.1.3/go.mod h1:CxEZVgJfnwOzUt/67YYnuw5uunb1t5oAoGpCrtIcPiE=
+github.com/suborbital/hive v0.1.4 h1:+ywO+vh/b/VdBDeGp6033zhcN5bQ8cPwVA8duiuWWoA=
 github.com/suborbital/vektor v0.1.1/go.mod h1:tJ4gA2P8NWC4Pdu0TgpSBWZHuZ1Qhp+r5RlsqyIqdyw=
 github.com/suborbital/vektor v0.1.3 h1:rC5ic4FnjmcbizmV/WAQt67QkF6eJ7jHSsuy8IFC2bc=
 github.com/suborbital/vektor v0.1.3/go.mod h1:tJ4gA2P8NWC4Pdu0TgpSBWZHuZ1Qhp+r5RlsqyIqdyw=

--- a/wasm/handlebundle.go
+++ b/wasm/handlebundle.go
@@ -1,0 +1,50 @@
+package wasm
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/suborbital/hive-wasm/bundle"
+	"github.com/suborbital/hive/hive"
+)
+
+// HandleBundleAtPath loads a .wasm.zip file into the hive instance
+func HandleBundleAtPath(h *hive.Hive, path string) error {
+	if !strings.HasSuffix(path, ".wasm.zip") {
+		return fmt.Errorf("cannot load bundle %s, does not have .wasm.zip extension", filepath.Base(path))
+	}
+
+	bundle, err := bundle.Read(path)
+	if err != nil {
+		return errors.Wrap(err, "failed to ReadBundle")
+	}
+
+	return HandleBundle(h, bundle)
+}
+
+// HandleBundle loads a .wasm.zip file into the hive instance
+func HandleBundle(h *hive.Hive, bundle *bundle.Bundle) error {
+	if err := bundle.Directive.Validate(); err != nil {
+		return errors.Wrap(err, "failed to Validate bundle directive")
+	}
+
+	for i, r := range bundle.Runnables {
+		runner := newRunnerWithRef(&bundle.Runnables[i])
+
+		jobName := strings.Replace(r.Name, ".wasm", "", -1)
+		fqfn, err := bundle.Directive.FQFN(jobName)
+		if err != nil {
+			return errors.Wrapf(err, "failed to FQFN for %s", jobName)
+		}
+
+		// mount both the "raw" name and the fqfn in case
+		// multiple bundles with conflicting names get mounted
+		h.Handle(jobName, runner)
+		h.Handle(fqfn, runner)
+
+	}
+
+	return nil
+}

--- a/wasm/wasmrunnable.go
+++ b/wasm/wasmrunnable.go
@@ -3,6 +3,7 @@ package wasm
 import (
 	"encoding/json"
 
+	"github.com/suborbital/hive-wasm/bundle"
 	"github.com/suborbital/hive/hive"
 
 	"github.com/pkg/errors"
@@ -15,7 +16,21 @@ type Runner struct {
 
 // NewRunner returns a new *Runner
 func NewRunner(filepath string) *Runner {
-	return newRunnerWithEnvironment(newEnvironment("", filepath))
+	ref := &bundle.WasmModuleRef{
+		Filepath: filepath,
+	}
+
+	return newRunnerWithRef(ref)
+}
+
+func newRunnerWithRef(ref *bundle.WasmModuleRef) *Runner {
+	environment := newEnvironment(ref)
+
+	r := &Runner{
+		env: environment,
+	}
+
+	return r
 }
 
 func newRunnerWithEnvironment(env *wasmEnvironment) *Runner {


### PR DESCRIPTION
`subo` needs the bundlep package to run, but it should not need to depend on Wasmer/CGO, so this PR pulls bundle out of the wasm package.