### PR TITLE
Added swift API package

### DIFF
--- a/api/swift/suborbital/.gitignore
+++ b/api/swift/suborbital/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/

--- a/api/swift/suborbital/.hive.yaml
+++ b/api/swift/suborbital/.hive.yaml
@@ -1,0 +1,2 @@
+lang: swift
+name: suborbital

--- a/api/swift/suborbital/Package.swift
+++ b/api/swift/suborbital/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "suborbital",
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "suborbital",
+            dependencies: []),
+        .testTarget(
+            name: "suborbitalTests",
+            dependencies: ["suborbital"]),
+    ]
+)

--- a/api/swift/suborbital/README.md
+++ b/api/swift/suborbital/README.md
@@ -1,0 +1,3 @@
+# Suborbital FFI API
+
+Swift implementation of the Suborbital FFI API

--- a/api/swift/suborbital/Sources/suborbital/lib.swift
+++ b/api/swift/suborbital/Sources/suborbital/lib.swift
@@ -1,0 +1,67 @@
+
+@_silgen_name("return_result_swift")
+func return_result(result_pointer: UnsafeRawPointer, result_size: Int32, ident: Int32)
+@_silgen_name("log_msg_swift")
+func log_msg_swift(pointer: UnsafeRawPointer, size: Int32, level: Int32, ident: Int32)
+
+// keep track of the current ident
+var CURRENT_IDENT: Int32 = 0
+
+// the Runnable instance currently being used
+var RUNNABLE: Runnable = defaultRunnable()
+
+// the protocol that users conform to to make their package a Runnable
+public protocol Runnable {
+    func run(input: String) -> String
+}
+
+// something to hold the Runnable's place until set is called
+class defaultRunnable: Runnable {
+    func run(input: String) -> String {
+        return ""
+    }
+}
+
+public func set(runnable: Runnable) {
+    RUNNABLE = runnable
+}
+
+public func log_info(msg: String) {
+    let printCount = Int32(msg.utf8.count)
+
+    let _ = msg.withCString( { (msgPtr) -> UInt in
+        log_msg_swift(pointer: msgPtr, size: printCount, level: 3, ident: CURRENT_IDENT)
+        return 0
+    })
+}
+
+@_cdecl("run_e")
+func run_e(pointer: UnsafeRawPointer, size: Int32, ident: Int32) {
+    CURRENT_IDENT = ident
+    
+    // convert the bytes to a string
+    let typed: UnsafePointer<UInt8> = pointer.bindMemory(to: UInt8.self, capacity: Int(size))
+    let inString = String(cString: typed)
+    
+    // call the user-provided run function
+    let retString = RUNNABLE.run(input: inString)
+
+    // convert the output to a usable pointer/size combo
+    let count = Int32(retString.utf8.count)
+    
+    let _ = retString.withCString({ (retPtr) -> UInt in
+        return_result(result_pointer: retPtr, result_size: count, ident: ident)
+        return 0
+    })
+}
+
+@_cdecl("allocate")
+func allocate(size: Int) -> UnsafeMutableRawPointer {
+  return UnsafeMutableRawPointer.allocate(byteCount: size, alignment: MemoryLayout<UInt8>.alignment)
+}
+
+@_cdecl("deallocate")
+func deallocate(pointer: UnsafeRawPointer, size: Int) {
+    let ptr: UnsafePointer<UInt8> = pointer.bindMemory(to: UInt8.self, capacity: Int(size))
+    ptr.deallocate()
+}

--- a/api/swift/suborbital/Sources/suborbital/main.swift
+++ b/api/swift/suborbital/Sources/suborbital/main.swift
@@ -1,0 +1,13 @@
+
+class ExampleRunnable: Runnable {
+    func run(input: String) -> String {
+        log_info(msg: "testing")
+        
+        return "why hello " + input
+    }
+}
+
+@_cdecl("init")
+func `init`() {
+    set(runnable: ExampleRunnable())
+}

--- a/api/swift/suborbital/Tests/LinuxMain.swift
+++ b/api/swift/suborbital/Tests/LinuxMain.swift
@@ -1,0 +1,7 @@
+import XCTest
+
+import suborbitalTests
+
+var tests = [XCTestCaseEntry]()
+tests += suborbitalTests.allTests()
+XCTMain(tests)

--- a/api/swift/suborbital/Tests/suborbitalTests/XCTestManifests.swift
+++ b/api/swift/suborbital/Tests/suborbitalTests/XCTestManifests.swift
@@ -1,0 +1,9 @@
+import XCTest
+
+#if !canImport(ObjectiveC)
+public func allTests() -> [XCTestCaseEntry] {
+    return [
+        testCase(example2Tests.allTests),
+    ]
+}
+#endif

--- a/api/swift/suborbital/Tests/suborbitalTests/suborbitalTests.swift
+++ b/api/swift/suborbital/Tests/suborbitalTests/suborbitalTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+import class Foundation.Bundle
+
+final class suborbitalTests: XCTestCase {
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct
+        // results.
+
+        // Some of the APIs that we use below are available in macOS 10.13 and above.
+        guard #available(macOS 10.13, *) else {
+            return
+        }
+
+        let fooBinary = productsDirectory.appendingPathComponent("suborbital")
+
+        let process = Process()
+        process.executableURL = fooBinary
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: data, encoding: .utf8)
+
+        XCTAssertEqual(output, "Hello, world!\n")
+    }
+
+    /// Returns path to the built products directory.
+    var productsDirectory: URL {
+      #if os(macOS)
+        for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
+            return bundle.bundleURL.deletingLastPathComponent()
+        }
+        fatalError("couldn't find the products directory")
+      #else
+        return Bundle.main.bundleURL
+      #endif
+    }
+
+    static var allTests = [
+        ("testExample", testExample),
+    ]
+}

--- a/wasm/wasm_test.go
+++ b/wasm/wasm_test.go
@@ -73,6 +73,22 @@ func TestSwiftRaw(t *testing.T) {
 	}
 }
 
+func TestSwiftPackage(t *testing.T) {
+	h := hive.New()
+
+	doWasm := h.Handle("wasm", NewRunner("./testdata/suborbital.wasm"))
+
+	res, err := doWasm("what is up").Then()
+	if err != nil {
+		t.Error(errors.Wrap(err, "failed to Then"))
+		return
+	}
+
+	if string(res.([]byte)) != "why hello what is up" {
+		t.Error(fmt.Errorf("expected 'why hello what is up', got %q", string(res.([]byte))))
+	}
+}
+
 func TestWasmRunnerDataConversion(t *testing.T) {
 	h := hive.New()
 


### PR DESCRIPTION
This adds a proper Swift API package, similar to the Rust crate, to be consumed by Swift Runnables instead of bundling `lib.swift` with the tempates in subo.